### PR TITLE
Updated WebSocket Protocol with smaller Details

### DIFF
--- a/WEBSOCKETS.md
+++ b/WEBSOCKETS.md
@@ -191,30 +191,34 @@ Example:
 |0x5|0x2|Object ID (64-Bit)|Matrix (512-Bit)|
 |-|-|-|-|
 
-### Add to Translation
+### Set Translation
 
-The translated values are **32-Bit floats**.
+The translated values are **32-Bit floats**.  
+Default is (0,0,0).
 
 |0x5|0x3|Object ID (64-Bit)|X (32-Bit)|Y (32-Bit)|Z (32-Bit)|
 |-|-|-|-|-|-|
 
-### Add to Scale
+### Set Scale
 
-The scale values are **32-Bit floats**.
+The scale values are **32-Bit floats**.  
+Default is (1,1,1).
 
 |0x5|0x4|Object ID (64-Bit)|X (32-Bit)|Y (32-Bit)|Z (32-Bit)|
 |-|-|-|-|-|-|
 
-### Add to Rotation (Quaternion)
+### Set Rotation (Quaternion)
 
-The rotation value is a quaternion containing **32-Bit floats**.
+The rotation value is a quaternion containing **32-Bit floats**.  
+Default is (0,0,0,1).
 
 |0x5|0x5|Object ID (64-Bit)|X (32-Bit)|Y (32-Bit)|Z (32-Bit)|W (32-Bit)|
 |-|-|-|-|-|-|-|
 
-### Add to Rotation (Euler)
+### Set Rotation (Euler)
 
 The rotation value is a **32-Bit float**.  
+Default is 0.  
 Change the rotation axis by setting one of the following values:
 
 - X - 0


### PR DESCRIPTION
I added some implementation details (the packets are unchanged!) to handle possible inconsistencies and race conditions while connecting and disconnecting clients, and some open questions.

2 further things we probably need to discuss (sent via E-Mail):
1) Slice Plane Axis
Slicing on Unitys side is currently implemented by using two slice planes. One which is controlled by the server and one which is tracked by the tablet. The plan is, when creating a snapshot, to set the server slice plane to the current tablet position and send a create command.
The "main axis" will be the one from the server and Unity will translate between the axis orientations (right vs. left handedness).
OpenGL should be right-handed and Unity left-handed.

2) Object manipulation
Currently we only send messages to add to translation, rotation and scale values. What could happen is, that packets are dropped and the state is no longer consistent.
Should we change it to set absolute values instead?