### PR TITLE
Different Handling of Desync while loading Dataset

### DIFF
--- a/WEBSOCKETS.md
+++ b/WEBSOCKETS.md
@@ -145,7 +145,7 @@ IF NAK comes back, disconnect the client, as it can not synchronize and would de
 #### Client disconnects
 
 In case a client disconnects, it is assumed to have sent ACK, as it should not stop other clients from loading the dataset.  
-If all clients are disconnected, the server is on its own and will always assume ACK. The server can then operate offline.
+If all clients are disconnected, the server is on its own and will always assume ACK. The server then operates alone.
 
 ## Objects
 

--- a/WEBSOCKETS.md
+++ b/WEBSOCKETS.md
@@ -119,10 +119,13 @@ stateDiagram-v2
     L --> [*]
 ```
 
-If the server sends a load dataset command, because of network latency, it is possible for the clients to send other commands of their own while not having received the load command.  
-In this case, the server will buffer these commands and replay them after the loading is done.
+If the server sends a load dataset command, because of network latency, it is possible for a client to send other commands of their own while not yet having received the load command.  
+These commands are ignored by the server while waiting for dataset load.
 
-This sequence of operations might introduce race conditions in case a new client connects, or an existing client disconnects while dataset loading is in progress.
+* If the dataset load operation succeeds, those previous commands can simply be ignored.  
+* If the dataset load fails, the commands are lost and the server and client are no longer in sync. As both the server and client aren't expected to buffer commands to resolve such cases, the server has to send the entire state of the dataset to the client in an attempt to resynchronize.
+
+While dataset load is happening, clients might connect or disconnect:
 
 #### Client connects
 

--- a/WEBSOCKETS.md
+++ b/WEBSOCKETS.md
@@ -66,6 +66,11 @@ Server &rarr; Client
 |0x3|Client ID (64-bit)|
 |-|-|
 
+New clients need to be synchronized, in case objects have already been manipulated or snapshots were created.  
+In this case, the server sends commands that replicate its current state.
+
+The commands could be replayed from all previously received commands, or the server sends its own commands equivalent to the current state. Any command is ok, as long as the state is properly synchronized.
+
 ## Commands
 
 ### Reset

--- a/WEBSOCKETS.md
+++ b/WEBSOCKETS.md
@@ -67,9 +67,13 @@ Server &rarr; Client
 |-|-|
 
 New clients need to be synchronized, in case objects have already been manipulated or snapshots were created.  
-In this case, the server sends commands that replicate its current state.
+In this case, the server sends commands that replicate its current state, in this document called a sync command chain.
 
-The commands could be replayed from all previously received commands, or the server sends its own commands equivalent to the current state. Any command is ok, as long as the state is properly synchronized.
+## Sync Command Chain
+
+This is a special list of commands, only used to resynchronize clients with the current server state.
+
+The matrix of all objects is sent, followed by the add snapshot commands to replicate them as well.
 
 ## Commands
 
@@ -128,7 +132,7 @@ If the server sends a load dataset command, because of network latency, it is po
 These commands are ignored by the server while waiting for dataset load.
 
 * If the dataset load operation succeeds, those previous commands can simply be ignored.  
-* If the dataset load fails, the commands are lost and the server and client are no longer in sync. As both the server and client aren't expected to buffer commands to resolve such cases, the server has to send the entire state of the dataset to the client in an attempt to resynchronize.
+* If the dataset load fails, the commands are lost and the server and client are no longer in sync. As both the server and client aren't expected to buffer commands to resolve such cases, the server has to send the entire state of the dataset to the client in an attempt to resynchronize. See [Sync Command Chain](#sync-command-chain).
 
 While dataset load is happening, clients might connect or disconnect:
 


### PR DESCRIPTION
Following the previous pull request, these are the proposed changes to handle desynchronization while loading datasets.
My last comment from the previous pull request is copied here:

I think you're right, we should keep the current implementation.
If we change datasets successfully, the state of objects is already reset, so they are always in sync.

However, one case in which it would make sense to NAK the clients would be the following:
The server wants to change to a dataset, that a client doesn't have.
The client simultaneously sends a object manipulation command (which reaches the server after dataset load was sent --> message is discarded).
The client answers with NAK (it doesn't have the dataset).

Now we have two states:
The server in the state before the object manipulation command (because discarded).
The client after manipulating the object (the command doesn't require acknowledgement).

One way to resolve this, could be to "mark" clients which have sent commands while in the dataset loading process, and in case they NAK, send the state of the server to these clients (objects positions, snapshots, etc.).
What do you think about it?