### PR TITLE
added another snapshot create command to offset "Remove" and "ClearAll" commands

### DIFF
--- a/modules/Remote/iAUnityWebsocketServerTool.cpp
+++ b/modules/Remote/iAUnityWebsocketServerTool.cpp
@@ -102,6 +102,7 @@ namespace
 	enum class SnapshotCommandType : quint8
 	{
 		Create,
+		CreateDouble,
 		Remove,
 		ClearAll,
 		// must be last:


### PR DESCRIPTION
The Remove and Clear commands are currently offset by 1 and therefore don't follow the spec. This should fix it.
The command added is called "CreateDouble" because it was planned to have the same create command but with double instead of float.